### PR TITLE
[fix]user.rbの記述間違いを修正

### DIFF
--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -5,8 +5,8 @@ FactoryBot.define do
     name { "テスト太郎" }
     phone_number { "08012345678" }
     email { "test@example.com" }
-    birth_date { "Date.new(1990, 1, 1)" }
-    password ( "password123" )
-    BeeBits_id ( "testtarou" )
+    birth_date { Date.new(1990, 1, 1) }
+    password { "password123" }
+    BeeBits_id { "testtarou" }
   end
 end


### PR DESCRIPTION
user.rbの記述が一部間違っていたせいで、コンテナが立ち上がらなくなる状態だったため正しい形に修正しました。