### PR TITLE
【fix】Rails7.2から'TestFixtures#fixture_path'が廃止されたため修正

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,7 @@ GEM
       autoprefixer-rails (>= 9.1.0)
       popper_js (>= 2.11.8, < 3)
     builder (3.2.4)
+    byebug (11.1.3)
     capybara (3.40.0)
       addressable
       matrix
@@ -99,6 +100,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    coderay (1.1.3)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -152,6 +154,7 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
+    method_source (1.0.0)
     mini_mime (1.1.5)
     minitest (5.21.2)
     msgpack (1.7.2)
@@ -185,6 +188,16 @@ GEM
       ast (~> 2.4.1)
       racc
     popper_js (2.11.8)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
+    pry-nav (1.0.0)
+      pry (>= 0.9.10, < 0.15)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     psych (5.1.2)
       stringio
     public_suffix (5.0.4)
@@ -354,6 +367,9 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   mysql2 (~> 0.5)
+  pry-byebug
+  pry-nav
+  pry-rails
   puma (~> 6.4)
   rails (~> 7.1.3)
   rspec-rails (~> 6.1.1)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -52,7 +52,7 @@ end
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{Rails.root}/spec/fixtures"
+  config.fixture_paths = "#{Rails.root}/spec/fixtures"
   config.include FactoryBot::Syntax::Methods
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your


### PR DESCRIPTION
## PRの目的
Rspec実行時にエラーが発生し、Rails7.2から'TestFixtures#fixture_path'が廃止された事によるエラーだったため、推奨の形式に修正を行いました。

## 重点的に見て欲しいポイント


## 対象のissues


## 備考
