### PR TITLE
【fix】beebits_nameへの＠自動挿入の記述をコントローラーから削除

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -2,19 +2,12 @@
 
 module Users
   class RegistrationsController < Devise::RegistrationsController
-    before_action :configure_sign_up_params, only: [:create]
 
     private
 
     # Strong Parametersの設定
     def sign_up_params
       params.require(:user).permit(:name, :email, :password, :password_confirmation, :phone_number, :birthdate, :beebits_name)
-    end
-
-    # 新規登録時のStrong Parametersを設定
-    def configure_sign_up_params
-      # beebits_nameの冒頭に＠を自動で追加する処理
-      params[:user][:beebits_name] = "@#{params[:user][:beebits_name]}" unless params[:user][:beebits_name].blank?
     end
 
     def account_update_params


### PR DESCRIPTION
## PRの目的
registrations_controllerからbeebits_name冒頭への＠自動挿入用記述を削除しました。
バリデーションで戻された場合などに＠が増えて挿入されてしまうため、後にReact等で実装し、Rails上ではバリデーションで＠が無い場合弾くのみにしたいと思います。

## 重点的に見て欲しいポイント


## 対象のissues


## 備考
