### PR TITLE
【add】プロフィール画面のテストを追加

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -2,6 +2,8 @@
 
 class ProfilesController < ApplicationController
   before_action :set_user
+  before_action :authenticate_user!, only: %i[edit update]
+  before_action :authorize_user!, only: %i[edit update]
 
   def show
     @timelines = @user.timelines.order(created_at: :desc)
@@ -29,5 +31,10 @@ class ProfilesController < ApplicationController
   # プロフィールのパラメータを許可するメソッド
   def profile_params
     params.require(:user).permit(:name, :bio)
+  end
+
+  # 編集権限を確認するメソッド
+  def authorize_user!
+    redirect_to root_path, alert: '権限がありません。' unless @user == current_user
   end
 end

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,6 +1,16 @@
 <h1>プロフィール編集</h1>
 
 <%= form_with(model: @user, url: user_profile_path(@user), method: :put, local: true) do |form| %>
+  <% if @user.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(@user.errors.count, "エラー") %>が発生しました:</h2>
+      <ul>
+        <% @user.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
   <div>
     <%= form.label :name, '名前' %>
     <%= form.text_field :name %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -5,7 +5,7 @@
   <%= link_to 'プロフィールを編集', edit_user_profile_path(@user) %>
 </div>
 
-<div>
+<div class="user-posts">
   <% @timelines.each do |timeline| %>
     <%= render 'timelines/timeline', timeline: timeline %>
   <% end %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -2,7 +2,9 @@
   <h1><%= @user.name %></h1>
   <p><%= @user.beebits_name %></p>
   <p><%= @user.bio %></p>
-  <%= link_to 'プロフィールを編集', edit_user_profile_path(@user) %>
+  <% if @user == current_user %>
+    <%= link_to 'プロフィールを編集', edit_user_profile_path(@user) %>
+  <% end %>
 </div>
 
 <div class="user-posts">

--- a/app/views/timelines/_timeline.html.erb
+++ b/app/views/timelines/_timeline.html.erb
@@ -1,6 +1,6 @@
 <div>
   <div>
-    <strong><%= timeline.user.name %></strong> <%= timeline.user.beebits_name %>
+    <strong><%= link_to timeline.user.name, user_profile_path(timeline.user) %></strong> <%= timeline.user.beebits_name %>
   </div>
   <div>
     <%= timeline.content %>

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -22,6 +22,8 @@ ja:
               too_long: "は%{count}文字以内で入力してください"
             password_confirmation:
               confirmation: "が一致しません"
+            bio:
+              too_long: "は%{count}文字以内で入力してください"
     attributes:
       user:
         name: "名前"
@@ -29,6 +31,7 @@ ja:
         phone_number: "電話番号"
         birthdate: "生年月日"
         beebits_name: "BeeBitsユーザー名"
+        bio: "自己紹介"
         confirmation_sent_at: パスワード確認送信時刻
         confirmation_token: パスワード確認用トークン
         confirmed_at: パスワード確認時刻

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   }
   root 'timelines#index'
   resources :timelines
-  resources :users, only: [] do
+  resources :users, only: [:show] do
     resource :profile, only: %i[show edit update], controller: 'profiles'
   end
   post 'favorites/:id', to: 'favorites#create', as: 'add_to_favorites'

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,19 +5,21 @@ FactoryBot.define do
     name { '蜜蜂太郎' }
     email { 'beebits@example.com' }
     phone_number { '08012345678' }
-    birthdate { Date.new(1995, 0o1, 0o1) }
+    birthdate { Date.new(1995, 1, 1) }
     beebits_name { '@bee_bits123' }
     password { 'password123' }
     password_confirmation { 'password123' }
+    bio { 'これはサンプルの自己紹介テキストです。' }
 
     trait :dummy_user do
       name { '蜜蜂次郎' }
       email { 'beebits2@example.com' }
       phone_number { '09012345678' }
-      birthdate { Date.new(1996, 0o1, 0o1) }
+      birthdate { Date.new(1996, 1, 1) }
       beebits_name { '@bee_bits456' }
       password { 'password456' }
       password_confirmation { 'password456' }
+      bio { 'これは別のサンプルの自己紹介テキストです。' }
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe User, type: :model do
   describe '#validation' do
     context '名前の場合' do
       let(:user) { build(:user, name:) }
-      # let(:user) {build(:user, name: name) }
 
       context '空の場合' do
         let(:name) { nil }
@@ -36,7 +35,8 @@ RSpec.describe User, type: :model do
 
       context '3文字の場合' do
         let(:name) { '蜜蜂太' }
-        it 'エラーが表示されること' do
+
+        it 'エラーが表示されないこと' do
           expect(user).to be_valid
         end
       end
@@ -137,15 +137,6 @@ RSpec.describe User, type: :model do
     context '電話番号の場合' do
       let(:user) { build(:user, phone_number:) }
 
-      # context '空の場合' do
-      #   let(:phone_number) { nil }
-
-      #   it 'エラーが表示されること' do
-      #     user.valid?
-      #     expect(user.errors.full_messages).to include('')
-      #   end
-      # end
-
       context '形式が日本国内の電話番号以外の場合' do
         let(:phone_number) { '01012345678' }
 
@@ -198,7 +189,7 @@ RSpec.describe User, type: :model do
       context '15歳の場合' do
         let(:birthdate) { 15.years.ago.strftime('%Y-%m-%d') }
 
-        it 'エラーが表示されること' do
+        it 'エラーが表示されないこと' do
           expect(user).to be_valid
         end
       end
@@ -206,7 +197,7 @@ RSpec.describe User, type: :model do
       context '16歳の場合' do
         let(:birthdate) { 16.years.ago.strftime('%Y-%m-%d') }
 
-        it 'エラーが表示されること' do
+        it 'エラーが表示されないこと' do
           expect(user).to be_valid
         end
       end
@@ -354,7 +345,7 @@ RSpec.describe User, type: :model do
         let(:password) { "#{'a' * 120}123456789" }
         let(:password_confirmation) { "#{'a' * 120}123456789" }
 
-        it 'エラーが表示さること' do
+        it 'エラーが表示されること' do
           user.valid?
           expect(user.errors.full_messages).to include('パスワード は128文字以内で入力してください')
         end
@@ -370,6 +361,35 @@ RSpec.describe User, type: :model do
         it 'エラーが表示されること' do
           user.valid?
           expect(user.errors.full_messages).to include('パスワード(確認用) が一致しません')
+        end
+      end
+    end
+
+    context '自己紹介テキストの場合' do
+      let(:user) { build(:user, bio:) }
+
+      context '空の場合' do
+        let(:bio) { nil }
+
+        it 'エラーが表示されないこと' do
+          expect(user).to be_valid
+        end
+      end
+
+      context '160文字の場合' do
+        let(:bio) { 'a' * 160 }
+
+        it 'エラーが表示されないこと' do
+          expect(user).to be_valid
+        end
+      end
+
+      context '161文字の場合' do
+        let(:bio) { 'a' * 161 }
+
+        it 'エラーが表示されること' do
+          user.valid?
+          expect(user.errors.full_messages).to include('自己紹介 は160文字以内で入力してください')
         end
       end
     end

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Profiles', type: :system do
+  describe 'プロフィール画面' do
+    let(:user) { create(:user, bio: 'これはサンプルの自己紹介テキストです。') }
+    let(:other_user) { create(:user, :dummy_user) }
+    let!(:user_post) { create(:timeline, user:, content: '自分の投稿') }
+    let!(:other_user_post) { create(:timeline, user: other_user, content: '他者の投稿') }
+
+    before do
+      visit new_user_session_path
+      fill_in 'BeeBitsユーザー名', with: user.beebits_name
+      fill_in 'パスワード', with: user.password
+      click_on 'ログイン'
+    end
+
+    context '自身のプロフィール画面の場合' do
+      it '自分の投稿のみが表示されること' do
+        visit user_profile_path(user)
+        expect(page).to have_content('自分の投稿')
+        expect(page).not_to have_content('他者の投稿')
+      end
+
+      it '自己紹介テキストが表示されること' do
+        visit user_profile_path(user)
+        expect(page).to have_content('これはサンプルの自己紹介テキストです。')
+      end
+
+      it '自己紹介テキストを編集できること' do
+        visit edit_user_profile_path(user)
+        fill_in '自己紹介', with: '新しい自己紹介テキストです。'
+        click_on '更新'
+        expect(page).to have_content('新しい自己紹介テキストです。')
+      end
+
+      it '自己紹介テキストの文字数制限が適用されること' do
+        visit edit_user_profile_path(user)
+        fill_in '自己紹介', with: 'a' * 161
+        click_on '更新'
+        expect(page).to have_content('自己紹介 は160文字以内で入力してください')
+      end
+    end
+
+    context '他者のプロフィール画面の場合' do
+      before do
+        visit destroy_user_session_path
+        visit new_user_session_path
+        fill_in 'BeeBitsユーザー名', with: other_user.beebits_name
+        fill_in 'パスワード', with: other_user.password
+        click_on 'ログイン'
+      end
+
+      # it '他者の投稿のみが表示されること' do
+      #   visit user_profile_path(user)
+      #   expect(page).to have_content('他者の投稿')
+      #   expect(page).not_to have_content('自分の投稿')
+      # end
+
+      # it '他者の自己紹介テキストが表示されること' do
+      #   visit user_profile_path(user)
+      #   expect(page).to have_content('これはサンプルの自己紹介テキストです。')
+      # end
+    end
+  end
+end

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Profiles', type: :system do
   describe 'プロフィール画面' do
     let(:user) { create(:user, bio: 'これはサンプルの自己紹介テキストです。') }
-    let(:other_user) { create(:user, :dummy_user) }
+    let(:other_user) { create(:user, :dummy_user, bio: 'これは別のサンプルの自己紹介テキストです。') }
     let!(:user_post) { create(:timeline, user:, content: '自分の投稿') }
     let!(:other_user_post) { create(:timeline, user: other_user, content: '他者の投稿') }
 
@@ -44,24 +44,24 @@ RSpec.describe 'Profiles', type: :system do
     end
 
     context '他者のプロフィール画面の場合' do
-      before do
-        visit destroy_user_session_path
-        visit new_user_session_path
-        fill_in 'BeeBitsユーザー名', with: other_user.beebits_name
-        fill_in 'パスワード', with: other_user.password
-        click_on 'ログイン'
+      it '他者の投稿のみが表示されること' do
+        visit timelines_path
+        click_on other_user.name
+        expect(page).to have_content('他者の投稿')
+        expect(page).not_to have_content('自分の投稿')
       end
 
-      # it '他者の投稿のみが表示されること' do
-      #   visit user_profile_path(user)
-      #   expect(page).to have_content('他者の投稿')
-      #   expect(page).not_to have_content('自分の投稿')
-      # end
+      it '他者の自己紹介テキストが表示されること' do
+        visit timelines_path
+        click_on other_user.name
+        expect(page).to have_content('これは別のサンプルの自己紹介テキストです。')
+      end
 
-      # it '他者の自己紹介テキストが表示されること' do
-      #   visit user_profile_path(user)
-      #   expect(page).to have_content('これはサンプルの自己紹介テキストです。')
-      # end
+      it '他者のプロフィール画面に編集ボタンが表示されないこと' do
+        visit timelines_path
+        click_on other_user.name
+        expect(page).not_to have_link('プロフィールを編集', href: edit_user_profile_path(other_user))
+      end
     end
   end
 end


### PR DESCRIPTION
## PRの目的
プロフィール画面のsystemテストとmodelのテストを追加します。
自己紹介テキストが表示されていること、自身の投稿のみが一覧表示されていることを含めています。

## 重点的に見て欲しいポイント


## 対象のissues


## 備考
