### PR TITLE
【add】他ユーザーのプロフィール画面への導線追加と編集機能の制限

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -2,6 +2,8 @@
 
 class ProfilesController < ApplicationController
   before_action :set_user
+  before_action :authenticate_user!, only: %i[edit update]
+  before_action :authorize_user!, only: %i[edit update]
 
   def show
     @timelines = @user.timelines.order(created_at: :desc)
@@ -29,5 +31,10 @@ class ProfilesController < ApplicationController
   # プロフィールのパラメータを許可するメソッド
   def profile_params
     params.require(:user).permit(:name, :bio)
+  end
+
+  # 編集権限を確認するメソッド
+  def authorize_user!
+    redirect_to root_path, alert: '権限がありません。' unless @user == current_user
   end
 end

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -2,7 +2,9 @@
   <h1><%= @user.name %></h1>
   <p><%= @user.beebits_name %></p>
   <p><%= @user.bio %></p>
-  <%= link_to 'プロフィールを編集', edit_user_profile_path(@user) %>
+  <% if @user == current_user %>
+    <%= link_to 'プロフィールを編集', edit_user_profile_path(@user) %>
+  <% end %>
 </div>
 
 <div class="user-posts">

--- a/app/views/timelines/_timeline.html.erb
+++ b/app/views/timelines/_timeline.html.erb
@@ -1,6 +1,6 @@
 <div>
   <div>
-    <strong><%= timeline.user.name %></strong> <%= timeline.user.beebits_name %>
+    <strong><%= link_to timeline.user.name, user_profile_path(timeline.user) %></strong> <%= timeline.user.beebits_name %>
   </div>
   <div>
     <%= timeline.content %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   }
   root 'timelines#index'
   resources :timelines
-  resources :users, only: [] do
+  resources :users, only: [:show] do
     resource :profile, only: %i[show edit update], controller: 'profiles'
   end
   post 'favorites/:id', to: 'favorites#create', as: 'add_to_favorites'

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -56,6 +56,12 @@ RSpec.describe 'Profiles', type: :system do
         click_on other_user.name
         expect(page).to have_content('これは別のサンプルの自己紹介テキストです。')
       end
+
+      it '他者のプロフィール画面に編集ボタンが表示されないこと' do
+        visit timelines_path
+        click_on other_user.name
+        expect(page).not_to have_link('プロフィールを編集', href: edit_user_profile_path(other_user))
+      end
     end
   end
 end

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Profiles', type: :system do
   describe 'プロフィール画面' do
     let(:user) { create(:user, bio: 'これはサンプルの自己紹介テキストです。') }
-    let(:other_user) { create(:user, :dummy_user) }
+    let(:other_user) { create(:user, :dummy_user, bio: 'これは別のサンプルの自己紹介テキストです。') }
     let!(:user_post) { create(:timeline, user:, content: '自分の投稿') }
     let!(:other_user_post) { create(:timeline, user: other_user, content: '他者の投稿') }
 
@@ -44,24 +44,18 @@ RSpec.describe 'Profiles', type: :system do
     end
 
     context '他者のプロフィール画面の場合' do
-      before do
-        visit destroy_user_session_path
-        visit new_user_session_path
-        fill_in 'BeeBitsユーザー名', with: other_user.beebits_name
-        fill_in 'パスワード', with: other_user.password
-        click_on 'ログイン'
+      it '他者の投稿のみが表示されること' do
+        visit timelines_path
+        click_on other_user.name
+        expect(page).to have_content('他者の投稿')
+        expect(page).not_to have_content('自分の投稿')
       end
 
-      # it '他者の投稿のみが表示されること' do
-      #   visit user_profile_path(user)
-      #   expect(page).to have_content('他者の投稿')
-      #   expect(page).not_to have_content('自分の投稿')
-      # end
-
-      # it '他者の自己紹介テキストが表示されること' do
-      #   visit user_profile_path(user)
-      #   expect(page).to have_content('これはサンプルの自己紹介テキストです。')
-      # end
+      it '他者の自己紹介テキストが表示されること' do
+        visit timelines_path
+        click_on other_user.name
+        expect(page).to have_content('これは別のサンプルの自己紹介テキストです。')
+      end
     end
   end
 end


### PR DESCRIPTION
## PRの目的
他ユーザーのプロフィール画面へアクセスするための導線を追加し、自身以外のプロフィール編集機能が使用できないように制限を加えました。
また、上記のテストを追加しました。

## 重点的に見て欲しいポイント


## 対象のissues


## 備考
