### PR TITLE
【fix】予約投稿機能について表示を削除、また関連ファイルをコメントアウト

### DIFF
--- a/app/views/timelines/index.html.erb
+++ b/app/views/timelines/index.html.erb
@@ -12,16 +12,6 @@
     </div>
   <% end %>
 </div>
-<div>
-  <%= form_with(model: @reserve_post_timeline, url: reserve_post_timelines_path, local: true) do |form| %>
-    <div>
-      <%= form.hidden_field :user_id, value: current_user.id %>
-      <%= form.label :content, "予約内容:" %>
-      <%= form.text_area :content, id: 'reserve_post_content', rows: 4 %>
-      <%= form.submit "予約投稿", class: "btn btn-primary" %>
-    </div>
-  <% end %>
-</div>
 
 <% @timelines.each do |t| %>
   <div>

--- a/spec/models/reserve_post_timeline_spec.rb
+++ b/spec/models/reserve_post_timeline_spec.rb
@@ -4,57 +4,57 @@ require 'rails_helper'
 
 RSpec.describe ReservePostTimeline, type: :model do
   describe '#validation' do
-    context 'テキスト投稿の場合' do
-      let(:user) { build(:user) }
-      let(:reserve_post_timeline) { build(:reserve_post_timeline, user:, content:) }
+    # context 'テキスト投稿の場合' do
+    #   let(:user) { build(:user) }
+    #   let(:reserve_post_timeline) { build(:reserve_post_timeline, user:, content:) }
 
-      context '入力が0文字の場合' do
-        let(:content) { '' }
+    #   context '入力が0文字の場合' do
+    #     let(:content) { '' }
 
-        it '無効であること' do
-          expect(reserve_post_timeline).not_to be_valid
-        end
-      end
+    #     it '無効であること' do
+    #       expect(reserve_post_timeline).not_to be_valid
+    #     end
+    #   end
 
-      context '入力が1文字の場合' do
-        let(:content) { '蜂' }
+    #   context '入力が1文字の場合' do
+    #     let(:content) { '蜂' }
 
-        it '有効であること' do
-          expect(reserve_post_timeline).to be_valid
-        end
-      end
+    #     it '有効であること' do
+    #       expect(reserve_post_timeline).to be_valid
+    #     end
+    #   end
 
-      context '入力が2文字の場合' do
-        let(:content) { '蜜蜂' }
+    #   context '入力が2文字の場合' do
+    #     let(:content) { '蜜蜂' }
 
-        it '有効であること' do
-          expect(reserve_post_timeline).to be_valid
-        end
-      end
+    #     it '有効であること' do
+    #       expect(reserve_post_timeline).to be_valid
+    #     end
+    #   end
 
-      context '入力が139文字の場合' do
-        let(:content) { '蜂' * 139 }
+    #   context '入力が139文字の場合' do
+    #     let(:content) { '蜂' * 139 }
 
-        it '有効であること' do
-          expect(reserve_post_timeline).to be_valid
-        end
-      end
+    #     it '有効であること' do
+    #       expect(reserve_post_timeline).to be_valid
+    #     end
+    #   end
 
-      context '入力が140文字の場合' do
-        let(:content) { '蜂' * 140 }
+    #   context '入力が140文字の場合' do
+    #     let(:content) { '蜂' * 140 }
 
-        it '有効であること' do
-          expect(reserve_post_timeline).to be_valid
-        end
-      end
+    #     it '有効であること' do
+    #       expect(reserve_post_timeline).to be_valid
+    #     end
+    #   end
 
-      context '入力が141文字の場合' do
-        let(:content) { '蜂' * 141 }
+    #   context '入力が141文字の場合' do
+    #     let(:content) { '蜂' * 141 }
 
-        it '無効であること' do
-          expect(reserve_post_timeline).not_to be_valid
-        end
-      end
-    end
+    #     it '無効であること' do
+    #       expect(reserve_post_timeline).not_to be_valid
+    #     end
+    #   end
+    # end
   end
 end

--- a/spec/system/reserve_post_timelines_spec.rb
+++ b/spec/system/reserve_post_timelines_spec.rb
@@ -4,20 +4,20 @@ require 'rails_helper'
 
 RSpec.describe 'ReservePostTimelines', type: :system do
   describe '予約投稿' do
-    before do
-      create(:user)
-      visit new_user_session_path
-      fill_in 'BeeBitsユーザー名', with: '@bee_bits123'
-      fill_in 'パスワード', with: 'password123'
-      click_on 'ログイン'
-    end
+    # before do
+    #   create(:user)
+    #   visit new_user_session_path
+    #   fill_in 'BeeBitsユーザー名', with: '@bee_bits123'
+    #   fill_in 'パスワード', with: 'password123'
+    #   click_on 'ログイン'
+    # end
 
-    it '予約投稿テーブルに値が保存されること' do
-      fill_in 'reserve_post_content', with: '予約投稿'
-      click_on '予約投稿'
-      expect(page).to have_content '投稿予約が完了しました。'
-      reserve_post_timeline = ReservePostTimeline.last
-      expect(reserve_post_timeline.content).to eq('予約投稿')
-    end
+    # it '予約投稿テーブルに値が保存されること' do
+    #   fill_in 'reserve_post_content', with: '予約投稿'
+    #   click_on '予約投稿'
+    #   expect(page).to have_content '投稿予約が完了しました。'
+    #   reserve_post_timeline = ReservePostTimeline.last
+    #   expect(reserve_post_timeline.content).to eq('予約投稿')
+    # end
   end
 end


### PR DESCRIPTION
## PRの目的
しばらく使用予定のない予約投稿機能について、投稿部分の削除とテストファイルのコメントアウトを行います。

## 重点的に見て欲しいポイント


## 対象のissues


## 備考
